### PR TITLE
Discord getuser patch

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -1,4 +1,4 @@
-# This workflow will run checks and validate the build
+# This workflow will run checks on a push or pull request to main
 
 name: GoBuild
 
@@ -21,10 +21,6 @@ jobs:
       with:
         go-version: '1.18'
 
-    - name: Lint & Vet
-      run: |
-       go vet .
-
-    - name: Validate Build
-      run: go build . 
+    - name: Vet
+      run: go vet .
   

--- a/data.go
+++ b/data.go
@@ -1,0 +1,10 @@
+package database
+
+import "errors"
+
+var (
+	ErrDeviceNoUsers = errors.New("There are no users associated with this device.")
+	ErrInvalidLogin  = errors.New("invalid login credentials")
+	ErrNoDiscordUser = errors.New("There are no users associated with this Discord account")
+	ErrUserNotFound  = errors.New("This user does not exist")
+)

--- a/device.go
+++ b/device.go
@@ -1,8 +1,6 @@
 package database
 
 import (
-	"errors"
-
 	"github.com/google/uuid"
 )
 
@@ -37,7 +35,7 @@ func (d *Device) GetUser() (User, error) {
 		}
 
 		if !result.Next() {
-			return user, errors.New("There are no users associated with this device.")
+			return user, ErrDeviceNoUsers
 		}
 		result.Scan(&d.UserId)
 	}

--- a/discord.go
+++ b/discord.go
@@ -37,7 +37,7 @@ func (d *Discord) GetUser() (User, error) {
 		}
 
 		if !result.Next() {
-			return user, errors.New("There are no users associated with this discord.")
+			return user, errors.New("There are no users associated with this Discord account")
 		}
 		result.Scan(&d.UserId)
 	}

--- a/discord.go
+++ b/discord.go
@@ -1,12 +1,8 @@
 package database
 
 import (
-	"errors"
-
 	"github.com/google/uuid"
 )
-
-var ErrNoDiscordUser = errors.New("There are no users associated with this Discord account")
 
 type Discord struct {
 	Id     string `json:"id"`

--- a/discord.go
+++ b/discord.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrNoUser = errors.New("There are no users associated with this Discord account")
+var ErrNoDiscordUser = errors.New("There are no users associated with this Discord account")
 
 type Discord struct {
 	Id     string `json:"id"`
@@ -39,7 +39,7 @@ func (d *Discord) GetUser() (User, error) {
 		}
 
 		if !result.Next() {
-			return user, ErrNoUser
+			return user, ErrNoDiscordUser
 		}
 		result.Scan(&d.UserId)
 	}

--- a/discord.go
+++ b/discord.go
@@ -6,6 +6,8 @@ import (
 	"github.com/google/uuid"
 )
 
+var ErrNoUser = errors.New("There are no users associated with this Discord account")
+
 type Discord struct {
 	Id     string `json:"id"`
 	UserId string `json:"userId"`
@@ -37,7 +39,7 @@ func (d *Discord) GetUser() (User, error) {
 		}
 
 		if !result.Next() {
-			return user, errors.New("There are no users associated with this Discord account")
+			return user, ErrNoUser
 		}
 		result.Scan(&d.UserId)
 	}

--- a/errors.go
+++ b/errors.go
@@ -3,8 +3,8 @@ package database
 import "errors"
 
 var (
-	ErrDeviceNoUsers = errors.New("There are no users associated with this device.")
-	ErrInvalidLogin  = errors.New("invalid login credentials")
+	ErrDeviceNoUsers = errors.New("There are no users associated with this device")
+	ErrInvalidLogin  = errors.New("Invalid login credentials")
 	ErrNoDiscordUser = errors.New("There are no users associated with this Discord account")
 	ErrUserNotFound  = errors.New("This user does not exist")
 )

--- a/user.go
+++ b/user.go
@@ -14,6 +14,23 @@ type User struct {
 	Blacklist Playlist   `json:"blacklist"`
 }
 
+// Attempt to find a User from a given username, return its ID if it exists
+func FindUser(username string) (string, error) {
+	var userId string
+
+	result, err := db.Query(`
+		select bin_to_uuid(id)
+		from user
+		where username = ?`,
+		username)
+
+	if err == nil && result.Next() {
+		result.Scan(&userId)
+	}
+
+	return userId, err
+}
+
 func (u *User) Create() error {
 	id := uuid.New().String()
 	blacklist := Playlist{"", "Blacklist", false, []Song{}}

--- a/user.go
+++ b/user.go
@@ -1,8 +1,6 @@
 package database
 
 import (
-	"errors"
-
 	"github.com/google/uuid"
 )
 
@@ -24,8 +22,12 @@ func FindUser(username string) (string, error) {
 		where username = ?`,
 		username)
 
-	if err == nil && result.Next() {
-		result.Scan(&userId)
+	if err == nil {
+		if result.Next() {
+			result.Scan(&userId)
+		} else {
+			err = ErrUserNotFound
+		}
 	}
 
 	return userId, err
@@ -67,7 +69,7 @@ func (u *User) Read() error {
 		result.Scan(&u.Id)
 		err = u.getPlaylists()
 	} else if err == nil {
-		err = errors.New("invalid login credentials")
+		err = ErrInvalidLogin
 	}
 
 	return err


### PR DESCRIPTION
- Declares custom errors as vars so that errors returned downstream can check compare error types
- Adds a `FindUser()` function that searches for a Tunebot user by username and returns either the user's ID or a custom error